### PR TITLE
Set item color only to original if the column is called 'All'

### DIFF
--- a/RetrospectiveExtension.Frontend/components/__tests__/feedbackColumn.test.tsx
+++ b/RetrospectiveExtension.Frontend/components/__tests__/feedbackColumn.test.tsx
@@ -34,6 +34,7 @@ describe('Feedback Column ', () => {
       const expectedAccentColor: string = testColumnProps.columns[columnItem.feedbackItem.originalColumnId]?.columnProperties?.accentColor;
 
       testColumnProps.accentColor = 'someOtherColor';
+      testColumnProps.columnId = 'some-other-column-uuid';
       testColumnProps.columnName = 'All';
 
       const feedbackItemProps = FeedbackColumn.createFeedbackItemProps(testColumnProps, testColumnProps.columnItems[0], true);

--- a/RetrospectiveExtension.Frontend/components/__tests__/feedbackColumn.test.tsx
+++ b/RetrospectiveExtension.Frontend/components/__tests__/feedbackColumn.test.tsx
@@ -34,7 +34,7 @@ describe('Feedback Column ', () => {
       const expectedAccentColor: string = testColumnProps.columns[columnItem.feedbackItem.originalColumnId]?.columnProperties?.accentColor;
 
       testColumnProps.accentColor = 'someOtherColor';
-      testColumnProps.columnId = 'some-other-column-uuid';
+      testColumnProps.columnId = 'all-column-uuid';
       testColumnProps.columnName = 'All';
 
       const feedbackItemProps = FeedbackColumn.createFeedbackItemProps(testColumnProps, testColumnProps.columnItems[0], true);
@@ -42,9 +42,10 @@ describe('Feedback Column ', () => {
       expect(feedbackItemProps.accentColor).toEqual(expectedAccentColor);
     });
 
-    it('should render with column accent color when the columnName is not All', () => {
+    it('should render with new column accent color when the columnName is not All', () => {
       const originalColor: string = testColumnProps.accentColor;
       testColumnProps.accentColor = 'someOtherColor';
+      testColumnProps.columnId = 'some-other-column-uuid';
       testColumnProps.columnName = 'someOtherColumn';
 
       const feedbackItemProps = FeedbackColumn.createFeedbackItemProps(testColumnProps, testColumnProps.columnItems[0], true);

--- a/RetrospectiveExtension.Frontend/components/__tests__/feedbackColumn.test.tsx
+++ b/RetrospectiveExtension.Frontend/components/__tests__/feedbackColumn.test.tsx
@@ -29,16 +29,26 @@ describe('Feedback Column ', () => {
       expect(feedbackItemProps.accentColor).toEqual(expectedAccentColor);
     });
 
-    it('should render with original column accent color when the column ids are different', () => {
+    it('should render with original column accent color when the columnName is All', () => {
       const columnItem: IColumnItem = testColumnProps.columnItems[0];
       const expectedAccentColor: string = testColumnProps.columns[columnItem.feedbackItem.originalColumnId]?.columnProperties?.accentColor;
 
       testColumnProps.accentColor = 'someOtherColor';
-      testColumnProps.columnId = 'some-other-column-uuid';
+      testColumnProps.columnName = 'All';
 
       const feedbackItemProps = FeedbackColumn.createFeedbackItemProps(testColumnProps, testColumnProps.columnItems[0], true);
 
       expect(feedbackItemProps.accentColor).toEqual(expectedAccentColor);
+    });
+
+    it('should render with column accent color when the columnName is not All', () => {
+      const originalColor: string = testColumnProps.accentColor;
+      testColumnProps.accentColor = 'someOtherColor';
+      testColumnProps.columnName = 'someOtherColumn';
+
+      const feedbackItemProps = FeedbackColumn.createFeedbackItemProps(testColumnProps, testColumnProps.columnItems[0], true);
+
+      expect(feedbackItemProps.accentColor).toEqual(originalColor);
     });
   })
 

--- a/RetrospectiveExtension.Frontend/components/feedbackColumn.tsx
+++ b/RetrospectiveExtension.Frontend/components/feedbackColumn.tsx
@@ -152,8 +152,11 @@ export default class FeedbackColumn extends React.Component<FeedbackColumnProps,
     columnItem: IColumnItem,
     isInteractable: boolean): IFeedbackItemProps => {
 
+    // Show original color on column 'All'
+    // see: "New 'Focus Mode' tab called 'All'", https://github.com/microsoft/vsts-extension-retrospectives/pull/543
     let accentColor: string = columnProps.accentColor;
-    if(columnItem.feedbackItem.originalColumnId !== columnProps.columnId) {
+    if(columnProps.columnName === 'All'
+       && columnItem.feedbackItem.originalColumnId !== columnProps.columnId) {
       accentColor = columnProps.columns[columnItem.feedbackItem.originalColumnId]?.columnProperties?.accentColor ?? columnProps.accentColor;
     }
 


### PR DESCRIPTION
# Pull Request

Relevant Issue(s): <!-- What issue(s) is this PR fixing  -->

## Description

<!-- Please provide a brief description of what this PR aims to do -->

## Bug or Feature?

- [ ] Bug fix
- [ ] New feature

## Fundamentals

- [ ] I have read the [**CONTRIBUTING**](https://github.com/microsoft/vsts-extension-retrospectives/blob/main/CONTRIBUTING.md)
document.
- [ ] My code follows the code style of this project.
- [ ] I have updated any relevant documentation accordingly.
- [ ] I have included an update blurb (50 words or less) at the top of `CHANGELOG.md`,
    to be included with the next release.
  - [ ] I have included a link to this PR in that blurb.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Accessibility

- [ ] I have tested my changes on both light and dark themes.
- [ ] I have tested my changes on both mobile and desktop views, when needed.
- [ ] I have included image descriptions and aria-labels where I can.

## Screenshots and Logs

<!-- Do you have any screenshots or logs that would show off your fix? -->
